### PR TITLE
Add Google Analytics tag

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type React from "react"
 import type { Metadata } from "next"
+import Script from "next/script"
 import { Inter, Montserrat } from "next/font/google"
 import "./globals.css"
 
@@ -48,6 +49,21 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="pt-BR" className={`${montserrat.variable} ${inter.variable}`}>
+      <head>
+        <Script
+          async
+          src="https://www.googletagmanager.com/gtag/js?id=G-W0ERY9SXNP"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'G-W0ERY9SXNP');
+          `}
+        </Script>
+      </head>
       <body className={inter.className}>{children}</body>
     </html>
   )


### PR DESCRIPTION
## Summary
- integrate Google Analytics gtag into global layout for site tracking

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_e_6899d85fdf74832dbc4fa34661d5b8bd